### PR TITLE
Script for running multiple small jobs

### DIFF
--- a/sbatch_scripts/many_small_jobs.sh
+++ b/sbatch_scripts/many_small_jobs.sh
@@ -10,29 +10,36 @@ module purge
 module load conda
 source activate windse
  
-# This stops the solver from filling all 36 cores
+# This stops the solver from filling all 36 cores of the node
 # Not using this may significantly slow down execution (100 times slower on Eagle)
 export OMP_NUM_THREADS=1
 
 
-# Number of times all processors run a job = # of jobs/ # of cores per node
-N_LOOP=2
-# Run 1 job per task
-N_JOB_PER_LOOP=$SLURM_NTASKS
+# Run 1 job per core
+N_JOB_PER_BATCH=$SLURM_NTASKS
+# Number of times all processors run a job = # of jobs/ # job per batch
+N_BATCH=2
 
-# Where to store Logs
+# Where to store logs
 mkdir -p LOGS
 
 
 # Run many small jobs
-for((j=0;j<$N_LOOP;j++))
+for((j=0;j<$N_BATCH;j++))
 do
 
-  for((i=0;i<$N_JOB_PER_LOOP;i++))
+  for((i=0;i<$N_JOB_PER_BATCH;i++))
   do
+    # Construct a unique job ID
+    jobid=$((i + j*N_JOB_PER_BATCH))
 
-    jobid=$((i + j*N_JOB_PER_LOOP))
-    windse run test.yaml -p 'general':'name':test_$jobid > LOGS/log$jobid &
+    # Create a unique name for this job and its output
+    jobname=$(printf "test_job_%03d" $jobid)
+    logname=$(printf "log_%03d" $jobid)
+
+    # Run each as a 1-core job, where -n XX can be adjusted as needed
+    # (e.g., srun -n 2... where N_JOB_PER_BATCH=18)
+    srun -n 1 windse run test.yaml -p 'general':'name':$jobname > LOGS/$logname &
 
   done
 

--- a/sbatch_scripts/many_small_jobs.sh
+++ b/sbatch_scripts/many_small_jobs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --account=windse
+#SBATCH --time=48:00:00
+#SBATCH --nodes=1
+#SBATCH --job-name=many_small_jobs
+
+ 
+# Load and activate your conda environment
+module purge
+module load conda
+source activate windse
+ 
+# This stops the solver from filling all 36 cores
+# Not using this may significantly slow down execution (100 times slower on Eagle)
+export OMP_NUM_THREADS=1
+
+
+# Number of times all processors run a job = # of jobs/ # of cores per node
+N_LOOP=2
+# Run 1 job per task
+N_JOB_PER_LOOP=$SLURM_NTASKS
+
+# Where to store Logs
+mkdir -p LOGS
+
+
+# Run many small jobs
+for((j=0;j<$N_LOOP;j++))
+do
+
+  for((i=0;i<$N_JOB;i++))
+  do
+
+    jobid=$((i + j*N_JOB))
+    windse run test.yaml -p 'general':'name':test_$jobid > LOGS/log$jobid &
+
+  done
+
+  #Wait until all jobs running on the node are done before launching the next batch
+  wait
+
+done
+
+# Finalize
+echo "All done"
+
+ 

--- a/sbatch_scripts/many_small_jobs.sh
+++ b/sbatch_scripts/many_small_jobs.sh
@@ -28,10 +28,10 @@ mkdir -p LOGS
 for((j=0;j<$N_LOOP;j++))
 do
 
-  for((i=0;i<$N_JOB;i++))
+  for((i=0;i<$N_JOB_PER_LOOP;i++))
   do
 
-    jobid=$((i + j*N_JOB))
+    jobid=$((i + j*N_JOB_PER_LOOP))
     windse run test.yaml -p 'general':'name':test_$jobid > LOGS/log$jobid &
 
   done


### PR DESCRIPTION
Running multiple small jobs without the proper options can lead to very slow run times.
The script provided shows how to do it. We emphasize the importance of forcing OMP_NUM_THREADS=1, even when multi thread execution is disabled (like on Eagle for example).
