### PR TITLE
Fix constraints and objective output

### DIFF
--- a/windse/OptimizationManager.py
+++ b/windse/OptimizationManager.py
@@ -709,7 +709,7 @@ class Optimizer(object):
 
         h = []
         for i,c in enumerate(self.controls):
-            h.append(Constant(10))
+            h.append(Constant(10.0))
             # h.append(Constant(0.01*max(abs(float(self.bounds[1][i])),abs(float(self.bounds[1][i])))))
             # h.append(Constant(10.0*abs(float(self.bounds[1][i])-float(self.bounds[0][i]))/2.0))
             # h.append(Constant(0.01*abs(np.mean(self.bounds[1])+np.mean(self.bounds[0]))/2.0))

--- a/windse/ProblemManager.py
+++ b/windse/ProblemManager.py
@@ -499,6 +499,10 @@ class GenericProblem(object):
         self.farm.chord = self.chord
         self.farm.num_blade_segments = self.num_blade_segments
 
+    def SimpleControlUpdate(self):
+        self.u_k, self.p_k = split(self.up_k)
+        self.farm.SimpleControlUpdate()
+
 
     def ChangeWindAngle(self,inflow_angle):
         """

--- a/windse/WindFarmManager.py
+++ b/windse/WindFarmManager.py
@@ -351,14 +351,14 @@ class GenericWindFarm(object):
         for i in range(self.numturbs):
 
             # Update per turbine controls
-            self.mx[i] = Constant(self.x[i])
-            self.my[i] = Constant(self.y[i])
-            self.ma[i] = Constant(self.axial[i])
-            self.myaw[i] = Constant(self.yaw[i])
-            # self.mx[i].assign(self.x[i], annotate_tape=False) # this annotate_tape needs to be here because dolfin_adjoing Constant.assign doesnt use annotate=annotate_tape(kwargs) like everything else (check function for example)
-            # self.my[i].assign(self.y[i], annotate_tape=False)
-            # self.ma[i].assign(self.axial[i], annotate_tape=False)
-            # self.myaw[i].assign(self.yaw[i], annotate_tape=False)
+            # self.mx[i] = Constant(self.x[i])
+            # self.my[i] = Constant(self.y[i])
+            # self.ma[i] = Constant(self.axial[i])
+            # self.myaw[i] = Constant(self.yaw[i])
+            self.mx[i].assign(self.x[i]) # this annotate_tape needs to be here because dolfin_adjoing Constant.assign doesnt use annotate=annotate_tape(kwargs) like everything else (check function for example)
+            self.my[i].assign(self.y[i])
+            self.ma[i].assign(self.axial[i])
+            self.myaw[i].assign(self.yaw[i])
 
             # Update ground stuff
             self.mz[i] = BaseHeight(self.mx[i],self.my[i],self.dom.Ground)+float(self.HH[i])
@@ -368,12 +368,12 @@ class GenericWindFarm(object):
             # Update blade level controls
             if self.turbine_method == "alm" or self.force == "chord": 
                 for k in range(self.num_blade_segments):
-                    self.mcl[i][k] = Constant(self.cl[i][k])
-                    self.mcd[i][k] = Constant(self.cd[i][k])
-                    self.mchord[i][k] = Constant(self.chord[i][k])
-                    # self.mcl[i][k].assign(self.cl[i][k], annotate_tape=False)
-                    # self.mcd[i][k].assign(self.cd[i][k], annotate_tape=False)
-                    # self.mchord[i][k].assign(self.chord[i][k], annotate_tape=False)
+                    # self.mcl[i][k] = Constant(self.cl[i][k])
+                    # self.mcd[i][k] = Constant(self.cd[i][k])
+                    # self.mchord[i][k] = Constant(self.chord[i][k])
+                    self.mcl[i][k].assign(self.cl[i][k])
+                    self.mcd[i][k].assign(self.cd[i][k])
+                    self.mchord[i][k].assign(self.chord[i][k])
 
 
 

--- a/windse/WindFarmManager.py
+++ b/windse/WindFarmManager.py
@@ -351,10 +351,14 @@ class GenericWindFarm(object):
         for i in range(self.numturbs):
 
             # Update per turbine controls
-            self.mx[i].assign(self.x[i], annotate_tape=False) # this annotate_tape needs to be here because dolfin_adjoing Constant.assign doesnt use annotate=annotate_tape(kwargs) like everything else (check function for example)
-            self.my[i].assign(self.y[i], annotate_tape=False)
-            self.ma[i].assign(self.axial[i], annotate_tape=False)
-            self.myaw[i].assign(self.yaw[i], annotate_tape=False)
+            self.mx[i] = Constant(self.x[i])
+            self.my[i] = Constant(self.y[i])
+            self.ma[i] = Constant(self.axial[i])
+            self.myaw[i] = Constant(self.yaw[i])
+            # self.mx[i].assign(self.x[i], annotate_tape=False) # this annotate_tape needs to be here because dolfin_adjoing Constant.assign doesnt use annotate=annotate_tape(kwargs) like everything else (check function for example)
+            # self.my[i].assign(self.y[i], annotate_tape=False)
+            # self.ma[i].assign(self.axial[i], annotate_tape=False)
+            # self.myaw[i].assign(self.yaw[i], annotate_tape=False)
 
             # Update ground stuff
             self.mz[i] = BaseHeight(self.mx[i],self.my[i],self.dom.Ground)+float(self.HH[i])
@@ -364,9 +368,12 @@ class GenericWindFarm(object):
             # Update blade level controls
             if self.turbine_method == "alm" or self.force == "chord": 
                 for k in range(self.num_blade_segments):
-                    self.mcl[i][k].assign(self.cl[i][k], annotate_tape=False)
-                    self.mcd[i][k].assign(self.cd[i][k], annotate_tape=False)
-                    self.mchord[i][k].assign(self.chord[i][k], annotate_tape=False)
+                    self.mcl[i][k] = Constant(self.cl[i][k])
+                    self.mcd[i][k] = Constant(self.cd[i][k])
+                    self.mchord[i][k] = Constant(self.chord[i][k])
+                    # self.mcl[i][k].assign(self.cl[i][k], annotate_tape=False)
+                    # self.mcd[i][k].assign(self.cd[i][k], annotate_tape=False)
+                    # self.mchord[i][k].assign(self.chord[i][k], annotate_tape=False)
 
 
 
@@ -862,7 +869,7 @@ class GenericWindFarm(object):
         self.actuator_disks = Function(fs.tf_V)
         self.actuator_disks.vector()[:] = np.sum(actuator_array,axis=1)
         self.fprint("Projecting Turbine Force")
-        self.actuator_disks = project(self.actuator_disks,fs.V,solver_type='mumps',form_compiler_parameters={'quadrature_degree': fs.turbine_degree},**self.extra_kwarg)
+        self.actuator_disks = project(self.actuator_disks,fs.V,solver_type='cg',preconditioner_type="hypre_amg",form_compiler_parameters={'quadrature_degree': fs.turbine_degree},**self.extra_kwarg)
         
         self.actuator_disks_list = []
         for i in range(self.numturbs):
@@ -1009,7 +1016,7 @@ class GenericWindFarm(object):
 
         ### Save the actuator disks for post processing ###
         self.fprint("Projecting Turbine Force")
-        self.actuator_disks = project(rd,fs.V,solver_type='cg',**self.extra_kwarg)
+        self.actuator_disks = project(rd,fs.V,solver_type='cg',preconditioner_type="hypre_amg",**self.extra_kwarg)
         # self.actuator_disks = project(rd,fs.V,solver_type='mumps',**self.extra_kwarg)
 
         tf_stop = time.time()

--- a/windse/dolfin_adjoint_helper.py
+++ b/windse/dolfin_adjoint_helper.py
@@ -461,6 +461,7 @@ class ControlUpdaterBlock(Block):
                 if name in ["c_lift","c_drag","chord"]:
                     self.control_dict[name][turb_id][seg_id] = float(inputs[i])
                 elif name in ["up"]:
+                    # self.control_dict[name] = inputs[i]
                     self.control_dict[name].assign(inputs[i])
                     # self.control_dict[name].assign(inputs[i], annotate=False)
                 else:

--- a/windse/dolfin_adjoint_helper.py
+++ b/windse/dolfin_adjoint_helper.py
@@ -432,8 +432,8 @@ class ControlUpdaterBlock(Block):
 
     def recompute(self, markings=False):
         print(f"Forward Solve Time: {self.time}")
-        with stop_annotating():
-            self.Update()
+        # with stop_annotating():
+        self.Update()
 
         # Run original recompute
         Block.recompute(self, markings)
@@ -442,8 +442,8 @@ class ControlUpdaterBlock(Block):
     @no_annotations
     def evaluate_adj(self, markings=False):
         print(f"Adjoint Solve Time: {self.time}")
-        with stop_annotating():
-            self.Update()
+        # with stop_annotating():
+        self.Update()
 
         # Run original evaluate_adj
         Block.evaluate_adj(self, markings)
@@ -461,13 +461,14 @@ class ControlUpdaterBlock(Block):
                 if name in ["c_lift","c_drag","chord"]:
                     self.control_dict[name][turb_id][seg_id] = float(inputs[i])
                 elif name in ["up"]:
-                    self.control_dict[name].assign(inputs[i], annotate=False)
+                    self.control_dict[name].assign(inputs[i])
+                    # self.control_dict[name].assign(inputs[i], annotate=False)
                 else:
                     self.control_dict[name][turb_id] = float(inputs[i])
 
         # update farm Constants()
-        with stop_annotating():
-            self.problem.SimpleControlUpdate()
+        # with stop_annotating():
+        self.problem.SimpleControlUpdate()
 
 
 # ================================================================

--- a/windse/dolfin_adjoint_helper.py
+++ b/windse/dolfin_adjoint_helper.py
@@ -467,7 +467,7 @@ class ControlUpdaterBlock(Block):
 
         # update farm Constants()
         with stop_annotating():
-            self.farm.SimpleControlUpdate()
+            self.problem.SimpleControlUpdate()
 
 
 # ================================================================

--- a/windse/objective_functions/IntegralPower.py
+++ b/windse/objective_functions/IntegralPower.py
@@ -34,6 +34,16 @@ def objective(solver, inflow_angle = 0.0, first_call=False, annotate=True, **kwa
 
     # if not annotate:
     #     stop_annotating()
+    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),6.0))",x0=0,y0=0,z0=100,r=500, degree=5)
+
+    print("tf1: ",assemble(dot(solver.problem.tf,as_vector((1.0,0.0,0.0)))*dx))
+    print("tf2: ",assemble(dot(solver.problem.tf,as_vector((0.0,1.0,0.0)))*dx))
+    print("tf3: ",assemble(dot(solver.problem.tf,as_vector((0.0,0.0,1.0)))*dx))
+    print("uk1: ",assemble(dot(spherical_gaussian*solver.problem.u_k,as_vector((1.0,0.0,0.0)))*dx))
+    print("uk2: ",assemble(dot(spherical_gaussian*solver.problem.u_k,as_vector((0.0,1.0,0.0)))*dx))
+    print("uk3: ",assemble(dot(spherical_gaussian*solver.problem.u_k,as_vector((0.0,0.0,1.0)))*dx))
+
+
     J = assemble(dot(-solver.problem.tf,solver.problem.u_k)*dx)
     # J = assemble(dot(-solver.problem.tf,Constant((1.0,1.0,1.0)))*dx)
 

--- a/windse/objective_functions/IntegralPower.py
+++ b/windse/objective_functions/IntegralPower.py
@@ -34,15 +34,6 @@ def objective(solver, inflow_angle = 0.0, first_call=False, annotate=True, **kwa
 
     # if not annotate:
     #     stop_annotating()
-    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),6.0))",x0=0,y0=0,z0=100,r=500, degree=5)
-
-    print("tf1: ",assemble(dot(solver.problem.tf,as_vector((1.0,0.0,0.0)))*dx))
-    print("tf2: ",assemble(dot(solver.problem.tf,as_vector((0.0,1.0,0.0)))*dx))
-    print("tf3: ",assemble(dot(solver.problem.tf,as_vector((0.0,0.0,1.0)))*dx))
-    print("uk1: ",assemble(dot(spherical_gaussian*solver.problem.u_k,as_vector((1.0,0.0,0.0)))*dx))
-    print("uk2: ",assemble(dot(spherical_gaussian*solver.problem.u_k,as_vector((0.0,1.0,0.0)))*dx))
-    print("uk3: ",assemble(dot(spherical_gaussian*solver.problem.u_k,as_vector((0.0,0.0,1.0)))*dx))
-
 
     J = assemble(dot(-solver.problem.tf,solver.problem.u_k)*dx)
     # J = assemble(dot(-solver.problem.tf,Constant((1.0,1.0,1.0)))*dx)
@@ -84,7 +75,8 @@ def objective(solver, inflow_angle = 0.0, first_call=False, annotate=True, **kwa
                 tf = tf1*solver.problem.u_k[0]**2+tf2*solver.problem.u_k[1]**2+tf3*solver.problem.u_k[0]*solver.problem.u_k[1]
                 J_list[i+1] = assemble(dot(-tf,solver.problem.u_k)*dx,**solver.extra_kwarg)
             else:
-                print("WARNING: missing individual turbine actuator disk, only able to report full farm power")
+                pass
+                # print("WARNING: missing individual turbine actuator disk, only able to report full farm power")
 
         J_list[-1]=float(J)
 

--- a/windse/objective_functions/PointBlockage.py
+++ b/windse/objective_functions/PointBlockage.py
@@ -24,7 +24,8 @@ name = "point_blockage"
 ### Set default keyword argument values ###
 keyword_defaults = {
     "location": (0,0,0),
-    "radius": "radius"
+    "radius": "radius", 
+    "sharpness": 6.0
 }
 
 
@@ -40,18 +41,20 @@ def objective(solver, inflow_angle = 0.0, first_call=False, **kwargs):
     Keyword arguments:
         location: where the deficit is evaluated
         radius: the radius of the sphere (default: "radius" is the radius of the rotors)
+        sharpness: the power in the Gaussian larger=sharper edges
     '''
 
     # Get the location of the point measurement and symbolic coordinates for the mesh
     x0 = np.array(kwargs.pop("location"))
     r = np.array(kwargs.pop("radius"))
+    p = np.array(kwargs.pop("sharpness"))
 
     # get default radius
     if r == "radius":
         r = max(solver.problem.farm.RD)/2.0
 
     # build expression
-    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),6.0))",x0=x0[0],y0=x0[1],z0=x0[2],r=r, degree=5)
+    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),p))",x0=x0[0],y0=x0[1],z0=x0[2],r=r,p=p, degree=5)
 
     # Calculate the volume for normalization (this should result in a valid m/s measurement)
     dx = Measure('dx', domain=solver.problem.dom.mesh)

--- a/windse/objective_functions/PointBlockage.py
+++ b/windse/objective_functions/PointBlockage.py
@@ -51,7 +51,7 @@ def objective(solver, inflow_angle = 0.0, first_call=False, **kwargs):
         r = max(solver.problem.farm.RD)/2.0
 
     # build expression
-    spherical_gaussian = Expression("exp(-(((x[0] - x0)**2 + (x[1] - y0)**2 + (x[2] - z0)**2)/r)**6.0)",x0=x0[0],y0=x0[1],z0=x0[2],r=r, degree=5)
+    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),6.0))",x0=x0[0],y0=x0[1],z0=x0[2],r=r, degree=5)
 
     # Calculate the volume for normalization (this should result in a valid m/s measurement)
     dx = Measure('dx', domain=solver.problem.dom.mesh)

--- a/windse/objective_functions/PointBlockage.py
+++ b/windse/objective_functions/PointBlockage.py
@@ -24,8 +24,7 @@ name = "point_blockage"
 ### Set default keyword argument values ###
 keyword_defaults = {
     "location": (0,0,0),
-    "radius": "radius", 
-    "sharpness": 6.0
+    "radius": "radius"
 }
 
 
@@ -41,20 +40,18 @@ def objective(solver, inflow_angle = 0.0, first_call=False, **kwargs):
     Keyword arguments:
         location: where the deficit is evaluated
         radius: the radius of the sphere (default: "radius" is the radius of the rotors)
-        sharpness: the power in the Gaussian larger=sharper edges
     '''
 
     # Get the location of the point measurement and symbolic coordinates for the mesh
     x0 = np.array(kwargs.pop("location"))
     r = np.array(kwargs.pop("radius"))
-    p = np.array(kwargs.pop("sharpness"))
 
     # get default radius
     if r == "radius":
         r = max(solver.problem.farm.RD)/2.0
 
     # build expression
-    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),p))",x0=x0[0],y0=x0[1],z0=x0[2],r=r,p=p, degree=5)
+    spherical_gaussian = Expression("exp(-pow(((pow((x[0] - x0),2) + pow((x[1] - y0),2) + pow((x[2] - z0),2))/r),6.0))",x0=x0[0],y0=x0[1],z0=x0[2],r=r, degree=5)
 
     # Calculate the volume for normalization (this should result in a valid m/s measurement)
     dx = Measure('dx', domain=solver.problem.dom.mesh)


### PR DESCRIPTION
## Purpose
Fixes two bugs. First, by splitting up_k during the update step of ControlUpdater(), u_k and p_k update allowing for computation of objective values and constraints during optimization. Second, replacing assignment of control to creation of new Constants() in WindFarmManager restore taylor_test convergence of order 2. 

## Type of change
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
In order to properly test the Taylor test, we would need to setup a regression test for each objective. That might be too much.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation