### PR TITLE
Specify Python 3.8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 source $(conda info --base)/etc/profile.d/conda.sh
 
 ### Create the Environment
-conda create -y --name $1
+conda create -y --name $1 python=3.8.0
 conda activate $1
 
 ### Install conda-forge dependencies 


### PR DESCRIPTION
I think the install of `fenics=2019.1.0=py38_9` calls for Python 3.8

